### PR TITLE
added master brancher for triggering action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on:
   workflow_dispatch:
   push:
-    branches: main
+    branches: [ main, master ]
 
 
 jobs:


### PR DESCRIPTION
Your main branch is called "master", th new standard is to call it main. 

Anyway, I had to add "master" among the branches that are troggering the CI (and run the build action)